### PR TITLE
code snippets to use fh.auth in the app preview

### DIFF
--- a/application.js
+++ b/application.js
@@ -16,6 +16,21 @@ app.use(cors());
 app.use('/sys', mbaasExpress.sys(securableEndpoints));
 app.use('/mbaas', mbaasExpress.mbaas);
 
+/* uncomment this code if you want to use $fh.auth in the app preview
+ * localAuth is only used for local development. 
+ * If the app is deployed on the platform, 
+ * this function will be ignored and the request will be forwarded 
+ * to the platform to perform authentication.
+
+app.use('/box', mbaasExpress.auth({localAuth: function(req, cb){
+  return cb(null, {status:401, body: {"message": "bad request"}});
+}}));
+
+or
+
+app.use('/box', mbaasExpress.core({localAuth: {status:401, body: {"message": "not authorised”}}}));
+*/
+
 // allow serving of static files from the public directory
 app.use(express.static(__dirname + '/public'));
 


### PR DESCRIPTION
# Motivation 
Studio Preview/Local Development for Web Apps does not handle $fh.auth calls correctly

A new auth end was added to handle $fh.auth requests correctly in fh-mbaas-api.

Customer needs code snippets to show how the new endpoint should be used.

# Result
Added code snippets in welcome cloud app.

