### PR TITLE
remove hello GET API docs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,37 +9,19 @@ This is a blank 'hello world' FeedHenry MBaaS. Use it as a starting point for bu
 
 'Hello world' endpoint.
 
-## hello [GET]
-
-+ Request (query string)
-    + Query
-            `?hello=world`
-
-+ Response 200 (application/json)
-    + Body
-            ```
-            {
-              "msg": "Hello world"
-            }
-            ```
-
 ## hello [POST] 
 
 + Request (application/json)
     + Body
-            ```
             {
               "hello": "world"
             }
-            ```
 
 + Response 200 (application/json)
     + Body
-            ```
             {
               "msg": "Hello world"
             }
-            ```
 
 ## Build
 ```shell


### PR DESCRIPTION
## Motivation
The hello [GET] API documentation is wrong and doesn't work when trying to update it to use the `+ Parameters` key word to show that it uses a query string parameter as documented [here](https://apiblueprint.org/documentation/tutorial.html)

## Result
Remove this documentation and open a ticket for it since this doesn't effect the node 6 verification  and is a different docs issue. See opened ticket [here](https://issues.jboss.org/browse/RHMAP-16238)
