### PR TITLE
Fix dependency versions to match 3.18 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.2.0",
   "dependencies": {
     "body-parser": "~1.0.2",
-    "cors": "~2.2.0",
-    "express": "~4.0.0",
+    "cors": "~2.8.3",
+    "express": "~4.15.3",
     "fh-mbaas-api": "~7.0.15",
-    "request": "~2.40.0"
+    "request": "2.81.0"
   },
   "devDependencies": {
     "grunt": "~0.4.0",
@@ -43,3 +43,4 @@
   },
   "license": "Apache-2.0"
 }
+


### PR DESCRIPTION
Dependencies have been downgraded on master. This should bring it back to same versions as in 3.18.

JIRA: https://issues.jboss.org/browse/RHMAP-17362 