### PR TITLE
RHMAP-21948: bump fh-mbaas-api to 9.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "body-parser": "1.18.3",
     "cors": "~2.8.4",
     "express": "~4.16.3",
-    "fh-mbaas-api": "9.1.0",
+    "fh-mbaas-api": "9.1.4",
     "request": "2.88.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumping dependency to latest released version (https://github.com/feedhenry/fh-mbaas-api/blob/master/CHANGELOG.md#914---thurs-nov-1-2018) to include bug fixes.

JIRA: https://issues.jboss.org/browse/RHMAP-21948

Verification steps:
Import this PR into a studio and deploy with Node 10.
Test /hello endpoint.